### PR TITLE
"Update stepStart and stepEnd callbacks to support async execution"

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,5 +159,5 @@ Custom settings for a tutorial button
 | <a id="previousButton-1" name="previousButton-1"></a> `previousButton?` | [`IButtonOptions`](README.md#IButtonOptions) | Custom settings for the "Previous" button. |
 | <a id="selector" name="selector"></a> `selector?` | `string` | The CSS selector for the element to focus on. If not specified, the <br />provided instructions will display in the center of the screen. |
 | <a id="skipButton-1" name="skipButton-1"></a> `skipButton?` | [`IButtonOptions`](README.md#IButtonOptions) | Custom settings for the "Skip" button. |
-| <a id="stepEnd" name="stepEnd"></a> `stepEnd?` | () => `void` | Callback to execute when the step is ended. |
-| <a id="stepStart" name="stepStart"></a> `stepStart?` | () => `void` | Callback to execute when the step is started. |
+| <a id="stepEnd" name="stepEnd"></a> `stepEnd?` | () => `void` \| `Promise`\<`void`\> | Callback to execute when the step is ended. |
+| <a id="stepStart" name="stepStart"></a> `stepStart?` | () => `void` \| `Promise`\<`void`\> | Callback to execute when the step is started. |

--- a/ng-enjoyhint/src/lib/component/enjoy-hint.component.ts
+++ b/ng-enjoyhint/src/lib/component/enjoy-hint.component.ts
@@ -35,7 +35,7 @@ import {
 } from '@angular/cdk/overlay';
 import { TemplatePortal } from '@angular/cdk/portal';
 import { JsonPipe, NgClass } from '@angular/common';
-import { takeUntil } from 'rxjs/operators';
+import { first, takeUntil } from 'rxjs/operators';
 import { ArrowComponent } from '../support/arrow.component';
 import { ForceFieldComponent } from '../support/force-field.component';
 import { provideWindow } from '../util/dom-helpers';
@@ -190,10 +190,13 @@ export class EnjoyHintComponent {
       .pipe(
         takeUntil(this.thisIsDestroyed),
         filter(([e, s]) => !!e && !!s),
-        switchMap(([element, step]) => fromEvent(element!, step!.event))
+        switchMap(([element, step]) => fromEvent(element!, step!.event).pipe(
+          filter(() => !this.animating()),
+          first()
+        )),
       )
-      .subscribe(() => {
-        this.ref.tutorial.nextStep();
+      .subscribe(async () => {
+        await this.ref.tutorial.nextStep();
         if (!this.step()) {
           this.close(true);
         }
@@ -251,8 +254,8 @@ export class EnjoyHintComponent {
   previous() {
     this.ref.tutorial.previousStep();
   }
-  next() {
-    this.ref.tutorial.nextStep();
+  async next() {
+    await this.ref.tutorial.nextStep();
     if (!this.step()) {
       this.close(true);
     }

--- a/ng-enjoyhint/src/lib/lib.interfaces.ts
+++ b/ng-enjoyhint/src/lib/lib.interfaces.ts
@@ -93,11 +93,11 @@ export interface ITutorialStep {
   /**
    * Callback to execute when the step is started.
    */
-  stepStart?: () => void;
+  stepStart?: () => Promise<void> | void;
   /**
    * Callback to execute when the step is ended.
    */
-  stepEnd?: () => void;
+  stepEnd?: () => Promise<void> | void;
 }
 
 export interface ITemplateWithContext<T = unknown> {

--- a/ng-enjoyhint/src/lib/support/Tutorial.ts
+++ b/ng-enjoyhint/src/lib/support/Tutorial.ts
@@ -34,17 +34,17 @@ export class Tutorial {
     this._stepIndex.set(normalizedIndex);
   }
 
-  nextStep() {
-    this.endHook();
+  async nextStep() {
+    await this.endHook();
     this._stepIndex.update((index) => index + 1);
-    this.startHook();
+    await this.startHook();
   }
 
-  private startHook() {
+  private async startHook() {
     const currentStepIndex = this._stepIndex();
     const currentStep = this.step();
     try {
-      currentStep?.stepStart?.();
+      await currentStep?.stepStart?.();
     } catch (e) {
       console.error(
         `Error executing stepEnd hook for step ${currentStepIndex}`,
@@ -54,11 +54,11 @@ export class Tutorial {
     }
   }
 
-  private endHook() {
+  private async endHook() {
     const newStepIndex = this._stepIndex();
     const newStep = this.step();
     try {
-      newStep?.stepEnd?.();
+      await newStep?.stepEnd?.();
     } catch (e) {
       console.error(
         `Error executing stepStart hook for step ${newStepIndex}`,


### PR DESCRIPTION
This pull request updates the `stepStart` and `stepEnd` callbacks in the code to support async execution. Previously, these callbacks were defined as `() => void`, but now they can also be defined as `() => Promise<void>`. This change allows for more flexibility in handling asynchronous operations within the callbacks.